### PR TITLE
Add login authentication using .env credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SECRET_KEY=your-secret-key
+# Mehrere Benutzer können mit Komma getrennt angegeben werden
+# Format: benutzer:passwort
+USERS=admin:password,operator:secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+
+.env
+

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ verwendet werden.
 
 ## Starten
 ```bash
-pip install flask
+pip install -r requirements.txt
+cp .env.example .env  # Zugangsdaten eintragen
 python app.py
 ```
 
-Danach ist die Oberfläche unter `http://<server-ip>:8014/` erreichbar.
+Nach dem Start ist die Oberfläche unter `http://<server-ip>:8014/` erreichbar.
+Vor der Nutzung muss man sich mit einem der in der `.env` definierten
+Benutzernamen und Passwörtern anmelden.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+python-dotenv

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,10 @@
 </head>
 <body class="bg-light">
     <div class="container py-4">
-        <h1 class="mb-4">Web Steuerung</h1>
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="mb-0">Web Steuerung</h1>
+            <a href="{{ url_for('logout') }}" class="btn btn-secondary">Logout</a>
+        </div>
         <form method="post" class="mb-3">
             <div class="row g-2 align-items-center">
                 <div class="col-auto">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Anmeldung</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+    <div class="container py-4">
+        <h1 class="mb-4">Anmeldung</h1>
+        <form method="post" class="mb-3">
+            <div class="mb-3">
+                <label class="form-label" for="username">Benutzername</label>
+                <input type="text" name="username" id="username" class="form-control">
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="password">Passwort</label>
+                <input type="password" name="password" id="password" class="form-control">
+            </div>
+            {% if error %}
+                <div class="alert alert-danger">{{ error }}</div>
+            {% endif %}
+            <button type="submit" class="btn btn-primary">Login</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add login/logout routes secured with username/password
- store credentials in `.env` loaded via `python-dotenv`
- create login page template and add logout link
- document environment setup in README
- provide `.env.example`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68587bd17e188321b9c857943efb33de