### PR TITLE
Zeige Service-Status im Auswahlmenü

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,13 +104,13 @@ def index():
 
     service_dirs = find_service_dirs()
     dirs = list(service_dirs.keys())
+    # Ermittele den Status für jeden gefundenen Service
+    statuses = {d: get_service_status(service_dirs[d]) for d in dirs}
+
     path = request.form.get('path', dirs[0] if dirs else '')
     command_key = request.form.get('command')
     output = ''
-    status = ''
-    service = service_dirs.get(path, '')
-    if service:
-        status = get_service_status(service)
+    status = statuses.get(path, '')
     if command_key in COMMANDS and path:
         abs_path = os.path.abspath(os.path.join(BASE_DIR, path))
         if abs_path.startswith(os.path.abspath(BASE_DIR)):
@@ -128,6 +128,7 @@ def index():
         'index.html',
         base=BASE_DIR,
         dirs=dirs,
+        statuses=statuses,
         path=path,
         commands=COMMANDS,
         output=output,

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,11 @@
                 <div class="col-auto">
                     <select name="path" id="path" class="form-select">
                         {% for d in dirs %}
-                            <option value="{{ d }}" {% if d == path %}selected{% endif %}>{{ d }}</option>
+                            {% set st = statuses[d] %}
+                            <option value="{{ d }}" {% if d == path %}selected{% endif %}
+                                {% if st == 'gestartet' %}style="color: green;"{% elif st == 'gestoppt' %}style="color: red;"{% endif %}>
+                                {{ d }} ({{ st }})
+                            </option>
                         {% endfor %}
                     </select>
                 </div>


### PR DESCRIPTION
## Summary
- zeige für jeden Service den aktuellen Status im Dropdown an
- füge Einfärbung (grün/rot) je nach Status hinzu

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858813859c08321afe515cdcaa1d234