### PR TITLE
Improve service status detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Die Weboberfläche verwendet jetzt Bootstrap für ein moderneres Layout.
 
 Voreingestellte Befehle:
 
-- **Start Service** – `sudo systemctl start <service>.service`
-- **Stop Service** – `sudo systemctl stop <service>.service`
+- **Start Service** – `sudo systemctl start <service>`
+- **Stop Service** – `sudo systemctl stop <service>`
 - **Erneuern** – `erneuern`
 - Beim Aufrufen der Seite wird zusätzlich der Status des gewählten Service
-  mit `sudo systemctl status <service>.service` geprüft und angezeigt.
+  mit `sudo systemctl is-active <service>` geprüft und angezeigt.
 Dabei entspricht `<service>` dem Dateinamen der gefundenen `.service`-Datei.
 
 **Wichtig:** Das Ausführen beliebiger Befehle über eine Weboberfläche 

--- a/app.py
+++ b/app.py
@@ -29,12 +29,13 @@ def get_service_status(service: str) -> str:
     """Prüft mit systemctl, ob der Service aktiv ist."""
     try:
         result = subprocess.run(
-            ['sudo', 'systemctl', 'status', f'{service}.service'],
+            ['sudo', 'systemctl', 'is-active', service],
             capture_output=True,
             text=True,
             check=False,
         )
-        if 'Active: active' in result.stdout:
+        state = result.stdout.strip()
+        if state == 'active':
             return 'gestartet'
         else:
             return 'gestoppt'


### PR DESCRIPTION
## Summary
- use `systemctl is-active` to check service status directly
- fix README to match updated commands

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685882dca4d083218d0277d12f169021