### PR TITLE
Implement AJAX service status refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,12 @@
-from flask import Flask, request, render_template, redirect, url_for, session
+from flask import (
+    Flask,
+    request,
+    render_template,
+    redirect,
+    url_for,
+    session,
+    jsonify,
+)
 import os
 import subprocess
 import re
@@ -7,21 +15,20 @@ from dotenv import load_dotenv
 load_dotenv()
 
 app = Flask(__name__)
-app.secret_key = os.getenv('SECRET_KEY', os.urandom(24))
+app.secret_key = os.getenv("SECRET_KEY", os.urandom(24))
 
-users_env = os.getenv('USERS', '')
+users_env = os.getenv("USERS", "")
 USERS = {
-    u.split(':', 1)[0]: u.split(':', 1)[1]
-    for u in users_env.split(',') if ':' in u
+    u.split(":", 1)[0]: u.split(":", 1)[1] for u in users_env.split(",") if ":" in u
 }
 
-BASE_DIR = '/home/do1ffe'
+BASE_DIR = "/home/do1ffe"
 
 # Vordefinierte Befehle, die per Button ausgeführt werden können
 COMMANDS = {
-    'Start Service': 'sudo systemctl start {service}',
-    'Stop Service': 'sudo systemctl stop {service}',
-    'Erneuern': 'erneuern',
+    "Start Service": "sudo systemctl start {service}",
+    "Stop Service": "sudo systemctl stop {service}",
+    "Erneuern": "erneuern",
 }
 
 
@@ -29,46 +36,49 @@ def get_service_status(service: str) -> str:
     """Prüft mit systemctl, ob der Service aktiv ist."""
     try:
         result = subprocess.run(
-            ['sudo', 'systemctl', 'is-active', service],
+            ["sudo", "systemctl", "is-active", service],
             capture_output=True,
             text=True,
             check=False,
         )
         state = result.stdout.strip()
-        if state == 'active':
-            return 'gestartet'
+        if state == "active":
+            return "gestartet"
         else:
-            return 'gestoppt'
+            return "gestoppt"
     except Exception as e:
-        return f'Fehler beim Prüfen: {e}'
+        return f"Fehler beim Prüfen: {e}"
 
 
 def find_service_dirs():
     """Liest Systemd-Service-Dateien und ordnet Directories den Service-Namen zu."""
-    service_dir = '/etc/systemd/system'
+    service_dir = "/etc/systemd/system"
     dirs = {}
     if not os.path.isdir(service_dir):
         return dirs
     for name in os.listdir(service_dir):
-        if not name.endswith('.service'):
+        if not name.endswith(".service"):
             continue
         path = os.path.join(service_dir, name)
         try:
             result = subprocess.run(
-                ['sudo', 'grep', '-m', '1', '^WorkingDirectory=/home/', path],
+                ["sudo", "grep", "-m", "1", "^WorkingDirectory=/home/", path],
                 capture_output=True,
                 text=True,
                 check=False,
             )
             if result.returncode == 0 and result.stdout:
                 line = result.stdout.splitlines()[0].strip()
-                m = re.match(r'^WorkingDirectory=(/home/.*)', line)
+                m = re.match(r"^WorkingDirectory=(/home/.*)", line)
                 if m:
                     full_path = m.group(1)
-                    if os.path.basename(os.path.normpath(full_path)) == 'web-steuerung':
+                    if os.path.basename(os.path.normpath(full_path)) == "web-steuerung":
                         continue
                     base_abs = os.path.abspath(BASE_DIR)
-                    if os.path.commonpath([os.path.abspath(full_path), base_abs]) != base_abs:
+                    if (
+                        os.path.commonpath([os.path.abspath(full_path), base_abs])
+                        != base_abs
+                    ):
                         continue
                     rel = os.path.relpath(full_path, BASE_DIR)
                     if os.path.isdir(os.path.join(BASE_DIR, rel)):
@@ -78,55 +88,69 @@ def find_service_dirs():
     return dict(sorted(dirs.items()))
 
 
-@app.route('/login', methods=['GET', 'POST'])
+@app.route("/login", methods=["GET", "POST"])
 def login():
-    error = ''
-    if request.method == 'POST':
-        username = request.form.get('username', '')
-        password = request.form.get('password', '')
+    error = ""
+    if request.method == "POST":
+        username = request.form.get("username", "")
+        password = request.form.get("password", "")
         if USERS.get(username) == password:
-            session['username'] = username
-            return redirect(url_for('index'))
+            session["username"] = username
+            return redirect(url_for("index"))
         else:
-            error = 'Ung\u00fcltige Anmeldedaten'
-    return render_template('login.html', error=error)
+            error = "Ung\u00fcltige Anmeldedaten"
+    return render_template("login.html", error=error)
 
 
-@app.route('/logout')
+@app.route("/logout")
 def logout():
-    session.pop('username', None)
-    return redirect(url_for('login'))
+    session.pop("username", None)
+    return redirect(url_for("login"))
 
 
-@app.route('/', methods=['GET', 'POST'])
+@app.route("/statuses")
+def statuses():
+    """Liefert den Status aller Dienste als JSON."""
+    if "username" not in session:
+        return jsonify({"error": "unauthorized"}), 401
+
+    service_dirs = find_service_dirs()
+    dirs = list(service_dirs.keys())
+    data = {d: get_service_status(service_dirs[d]) for d in dirs}
+    return jsonify({"statuses": data})
+
+
+@app.route("/", methods=["GET", "POST"])
 def index():
-    if 'username' not in session:
-        return redirect(url_for('login'))
+    if "username" not in session:
+        return redirect(url_for("login"))
 
     service_dirs = find_service_dirs()
     dirs = list(service_dirs.keys())
     # Ermittele den Status für jeden gefundenen Service
     statuses = {d: get_service_status(service_dirs[d]) for d in dirs}
 
-    path = request.form.get('path', dirs[0] if dirs else '')
-    command_key = request.form.get('command')
-    output = ''
-    status = statuses.get(path, '')
+    path = request.form.get("path", dirs[0] if dirs else "")
+    command_key = request.form.get("command")
+    output = ""
+    status = statuses.get(path, "")
     if command_key in COMMANDS and path:
         abs_path = os.path.abspath(os.path.join(BASE_DIR, path))
         if abs_path.startswith(os.path.abspath(BASE_DIR)):
             try:
-                service = service_dirs.get(path, '')
+                service = service_dirs.get(path, "")
                 cmd_template = COMMANDS[command_key]
                 cmd = cmd_template.format(service=service)
-                result = subprocess.run(cmd, cwd=abs_path, shell=True, capture_output=True, text=True)
+                result = subprocess.run(
+                    cmd, cwd=abs_path, shell=True, capture_output=True, text=True
+                )
                 output = result.stdout + result.stderr
             except Exception as e:
                 output = str(e)
         else:
-            output = 'Ungültiger Pfad'
+            output = "Ungültiger Pfad"
     return render_template(
-        'index.html',
+        "index.html",
         base=BASE_DIR,
         dirs=dirs,
         statuses=statuses,
@@ -136,5 +160,6 @@ def index():
         status=status,
     )
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8014)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8014)

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
                     </select>
                 </div>
                 <div class="col-auto">
-                    <span class="fw-bold">Status:</span> {{ status }}
+                    <span class="fw-bold">Status:</span> <span id="currentStatus">{{ status }}</span>
                 </div>
                 <div class="col-auto">
                     {% for key in commands.keys() %}
@@ -39,5 +39,36 @@
         </form>
         <pre class="border p-3 bg-white rounded">{{ output }}</pre>
     </div>
+    <script>
+        async function fetchStatuses() {
+            try {
+                const response = await fetch("{{ url_for('statuses') }}");
+                if (!response.ok) return;
+                const data = await response.json();
+                const statuses = data.statuses || {};
+                const select = document.getElementById('path');
+                const statusSpan = document.getElementById('currentStatus');
+                for (const option of select.options) {
+                    const st = statuses[option.value];
+                    if (!st) continue;
+                    option.textContent = option.value + ' (' + st + ')';
+                    if (st === 'gestartet') {
+                        option.style.color = 'green';
+                    } else if (st === 'gestoppt') {
+                        option.style.color = 'red';
+                    } else {
+                        option.style.color = '';
+                    }
+                    if (option.selected) {
+                        statusSpan.textContent = st;
+                    }
+                }
+            } catch (e) {
+                console.error('Status fetch failed', e);
+            }
+        }
+        setInterval(fetchStatuses, 5000);
+        window.addEventListener('DOMContentLoaded', fetchStatuses);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/statuses` endpoint that returns the service states as JSON
- inject JavaScript on the index page to poll this endpoint every 5 seconds
- update HTML structure to support real-time status display

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask' -> installed requirements -> server started)*

------
https://chatgpt.com/codex/tasks/task_e_685884a69408832198a5e02151c28c7c