### PR TITLE
Add SECRET_KEY explanation to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# SECRET_KEY wird von Flask genutzt, um Sitzungs-Cookies kryptografisch
+# zu signieren. Ohne festen Schlüssel erzeugt die Anwendung bei jedem
+# Start einen zufälligen, wodurch bestehende Sessions ungültig werden.
+# Daher sollte hier ein ausreichend langer, geheimer Wert eingetragen werden.
 SECRET_KEY=your-secret-key
 # Mehrere Benutzer können mit Komma getrennt angegeben werden
 # Format: benutzer:passwort


### PR DESCRIPTION
## Summary
- add explanatory comments for `SECRET_KEY` in `.env.example`

## Testing
- `nl -ba .env.example`

------
https://chatgpt.com/codex/tasks/task_e_6858865c86808321876792a02c4abf51